### PR TITLE
fix: Add namespace for bundle path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Get Bundle S3 URI
         id: bundle-uri
         run: |
-          echo "::set-output name=uri::s3://${{ inputs.bucket_name }}/bundles/${{ steps.s3-cache.outputs.hash }}.tar.gz"
+          echo "::set-output name=uri::s3://${{ inputs.bucket_name }}/bundles/${{ github.repository }}/${{ inputs.app_name }}/${{ steps.s3-cache.outputs.hash }}.tar.gz"
 
       - name: Compress & Upload Bundle
         if: steps.s3-cache.outputs.processed == 'false'


### PR DESCRIPTION
Currently all bundles from all repos end up in the same key namespace. It's unlikely the hash will collide, but if there are two apps in the repo, then they will try to upload the same bundle. This fixes the problem.