### PR TITLE
feat: Default to job name for key prefix in S3 Cache action

### DIFF
--- a/actions/s3-cache/README.md
+++ b/actions/s3-cache/README.md
@@ -29,10 +29,10 @@ action in a step prior to running this action to ensure that's the case.
 
 ## Inputs
 
-| parameter   | description                                          | required | default |
-| ----------- | ---------------------------------------------------- | -------- | ------- |
-| bucket_name | Name of the S3 bucket to use for storing cache files | `true`   |         |
-| key_prefix  | Key prefix to use for the cache files                | `true`   |         |
+| parameter   | description                                                          | required | default |
+| ----------- | -------------------------------------------------------------------- | -------- | ------- |
+| bucket_name | Name of the S3 bucket to use for storing cache files                 | `true`   |         |
+| key_prefix  | Key prefix to use for the cache files. By default the job ID is used | `false`  |         |
 
 <!-- action-docs-inputs -->
 

--- a/actions/s3-cache/action.yml
+++ b/actions/s3-cache/action.yml
@@ -7,8 +7,8 @@ inputs:
         description: Name of the S3 bucket to use for storing cache files
         required: true
     key_prefix:
-        description: Key prefix to use for the cache files
-        required: true
+        description: Key prefix to use for the cache files. By default the job ID is used
+        required: false
 outputs:
     processed:
         description: Indicates if the job has already been performed for the current tree hash

--- a/actions/s3-cache/dist/restore/index.js
+++ b/actions/s3-cache/dist/restore/index.js
@@ -9612,8 +9612,9 @@ const core = __importStar(__nccwpck_require__(2186));
 const github = __importStar(__nccwpck_require__(5438));
 const utils_1 = __nccwpck_require__(691);
 (0, utils_1.runAction)(() => __awaiter(void 0, void 0, void 0, function* () {
+    var _a;
     const bucket = core.getInput('bucket_name', { required: true });
-    const keyPrefix = core.getInput('key_prefix', { required: true });
+    const keyPrefix = (_a = core.getInput('key_prefix')) !== null && _a !== void 0 ? _a : github.context.job;
     const repo = github.context.repo;
     const output = yield restoreS3Cache({ bucket, keyPrefix, repo });
     // Saving key and hash in "state" which can be retrieved by the

--- a/actions/s3-cache/restore.ts
+++ b/actions/s3-cache/restore.ts
@@ -12,7 +12,7 @@ import {getCurrentRepoTreeHash, fileExistsInS3, runAction} from '../utils'
 
 runAction(async () => {
     const bucket = core.getInput('bucket_name', {required: true})
-    const keyPrefix = core.getInput('key_prefix', {required: true})
+    const keyPrefix = core.getInput('key_prefix') ?? github.context.job
     const repo = github.context.repo
 
     const output = await restoreS3Cache({bucket, keyPrefix, repo})


### PR DESCRIPTION
We're always using `${{ github.job }}` as the key prefix anyhow, so might just as well have it as the default. Thanks @VictorPascualV for the suggestion.